### PR TITLE
feat: separate external public/private subnet ids

### DIFF
--- a/src/variables.tf
+++ b/src/variables.tf
@@ -56,9 +56,16 @@ variable "vpc_id" {
   default     = null
 }
 
-variable "subnet_ids" {
+variable "public_subnet_ids" {
   type        = list(string)
-  description = "Subnet IDs"
+  description = "Public subnet IDs"
+  nullable    = true
+  default     = null
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs"
   nullable    = true
   default     = null
 }


### PR DESCRIPTION
## what
* Separate the subnet id parameter into public and private subnet ids

## why
* In order to spawn both public and private workers when the `networking_stack` is set to `external` we need to pass both private and public subnets. A single parameter makes this difficult with atmos; this fix allows easier specification.
* More recent versions of runs-on split the subnets as well (https://runs-on.com/configuration/stack-config/#externalvpcpublicsubnetids)

## references
* Solves https://github.com/orgs/cloudposse/discussions/106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subnet configuration now requires separate public and private subnet parameters instead of a combined list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->