### PR TITLE
fix: correct CloudFormation parameter name for external VPC subnet IDs

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -1,9 +1,17 @@
 locals {
   enabled = module.this.enabled
 
+  # Extract version from template URL (e.g., "template-v2.11.0.yaml" -> "2.11.0")
+  # The parameter name changed from ExternalVpcSubnetIds to ExternalVpcPublicSubnetIds in v2.8.0
+  version_match            = regex("template-v([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.yaml", var.template_url)
+  template_version_major   = tonumber(local.version_match[0])
+  template_version_minor   = tonumber(local.version_match[1])
+  use_new_subnet_param     = local.template_version_major > 2 || (local.template_version_major == 2 && local.template_version_minor >= 8)
+  subnet_ids_param_name    = local.use_new_subnet_param ? "ExternalVpcPublicSubnetIds" : "ExternalVpcSubnetIds"
+
   external_vpc_id  = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
   networking_stack = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
-  subnet_ids       = var.subnet_ids != null ? { "ExternalVpcPublicSubnetIds" = join(",", var.subnet_ids) } : {}
+  subnet_ids       = var.subnet_ids != null ? { (local.subnet_ids_param_name) = join(",", var.subnet_ids) } : {}
   // If var.security_group_id is provided, we use it. Otherwise, if we are using the external networking stack, we create one.
   external_security_group_id = var.security_group_id != null ? { "ExternalVpcSecurityGroupId" = var.security_group_id } : {}
   // If var.security_group_id is not provided and we are using the external networking stack, we create one.

--- a/src/main.tf
+++ b/src/main.tf
@@ -3,11 +3,11 @@ locals {
 
   # Extract version from template URL (e.g., "template-v2.11.0.yaml" -> "2.11.0")
   # The parameter name changed from ExternalVpcSubnetIds to ExternalVpcPublicSubnetIds in v2.8.0
-  version_match            = regex("template-v([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.yaml", var.template_url)
-  template_version_major   = tonumber(local.version_match[0])
-  template_version_minor   = tonumber(local.version_match[1])
-  use_new_subnet_param     = local.template_version_major > 2 || (local.template_version_major == 2 && local.template_version_minor >= 8)
-  subnet_ids_param_name    = local.use_new_subnet_param ? "ExternalVpcPublicSubnetIds" : "ExternalVpcSubnetIds"
+  version_match          = regex("template-v([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.yaml", var.template_url)
+  template_version_major = tonumber(local.version_match[0])
+  template_version_minor = tonumber(local.version_match[1])
+  use_new_subnet_param   = local.template_version_major > 2 || (local.template_version_major == 2 && local.template_version_minor >= 8)
+  subnet_ids_param_name  = local.use_new_subnet_param ? "ExternalVpcPublicSubnetIds" : "ExternalVpcSubnetIds"
 
   external_vpc_id  = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
   networking_stack = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}

--- a/src/main.tf
+++ b/src/main.tf
@@ -3,7 +3,7 @@ locals {
 
   external_vpc_id  = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
   networking_stack = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
-  subnet_ids       = var.subnet_ids != null ? { "ExternalVpcSubnetIds" = join(",", var.subnet_ids) } : {}
+  subnet_ids       = var.subnet_ids != null ? { "ExternalVpcPublicSubnetIds" = join(",", var.subnet_ids) } : {}
   // If var.security_group_id is provided, we use it. Otherwise, if we are using the external networking stack, we create one.
   external_security_group_id = var.security_group_id != null ? { "ExternalVpcSecurityGroupId" = var.security_group_id } : {}
   // If var.security_group_id is not provided and we are using the external networking stack, we create one.
@@ -70,7 +70,7 @@ module "iam_policy" {
   ]
 }
 
-// Typically when runs-on is installed, and we're using the embedded networking stack, we need a security group. 
+// Typically when runs-on is installed, and we're using the embedded networking stack, we need a security group.
 // This is a batties included optional feature.
 module "security_group" {
   source  = "cloudposse/security-group/aws"


### PR DESCRIPTION
## What

Fixes the CloudFormation parameter name for external VPC subnet IDs and adds backwards compatibility for older template versions.

The parameter name changed from `ExternalVpcSubnetIds` to `ExternalVpcPublicSubnetIds` in RunsOn v2.8.0. This PR:

1. Parses the template version from the `template_url`
2. Uses `ExternalVpcPublicSubnetIds` for v2.8.0+
3. Uses `ExternalVpcSubnetIds` for older versions

## Why

When using external VPC networking with recent versions of RunsOn (v2.8.0+), the stack fails with:

```
Parameters: [ExternalVpcSubnetIds] do not exist in the template
```

## References

- [RunsOn Changelog](https://runs-on.com/changelog/)
- [RunsOn External vs Embedded Networking](https://runs-on.com/networking/embedded-vs-external/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced configuration handling with template version detection and improved parameter naming for subnet and security group settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->