### PR TITLE
feat: add private_subnet_ids variable with validation and documentation

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -56,10 +56,27 @@ components:
           VpcFlowLogRetentionInDays: 14
 ```
 
-### Embedded networking (Runs On managed VPC)
+## Networking Options
 
-When no VPC details are set, the component will create a new VPC and subnets via the CloudFormation template.
-Set the `VpcCidrBlock` parameter to the CIDR block of the VPC that will be created.
+RunsOn supports two mutually exclusive networking configurations:
+
+- **Embedded networking** (`networking_stack: embedded`): RunsOn creates and manages its own VPC with public
+  and private subnets via CloudFormation. This is the simplest option to get started.
+
+- **External networking** (`networking_stack: external`): You provide your own VPC with subnets. This gives
+  you full control over networking and is required when you need Transit Gateway connectivity, VPC peering,
+  or other advanced networking configurations.
+
+> **Important**: The `vpc_id`, `subnet_ids`, and `private_subnet_ids` variables only apply when using
+> `networking_stack: external`. If you set these variables with `networking_stack: embedded`, Terraform
+> will return an error because RunsOn creates its own networking resources in embedded mode.
+
+### Embedded networking (RunsOn managed VPC)
+
+When using embedded networking, RunsOn creates a new VPC with public and private subnets via the
+CloudFormation template. Set the `VpcCidrBlock` parameter to specify the CIDR block for the VPC.
+
+Do **not** set `vpc_id`, `subnet_ids`, or `private_subnet_ids` when using embedded networking.
 
 (`runs-on.yaml`)
 
@@ -84,7 +101,25 @@ components:
 
 ### External networking (Use existing VPC)
 
-Use an existing VPC by setting `vpc_id`, `subnet_ids`, and `security_group_id`.
+Use an existing VPC by setting `vpc_id`, `subnet_ids`, and optionally `private_subnet_ids`.
+
+**Subnet configuration:**
+
+- `subnet_ids` (public subnets): Used for runners by default, or when the `Private` parameter is `"false"`.
+  Maps to CloudFormation parameter `ExternalVpcPublicSubnetIds`.
+
+- `private_subnet_ids` (private subnets): Used for runners when `Private` parameter is `"true"` or `"always"`.
+  Maps to CloudFormation parameter `ExternalVpcPrivateSubnetIds`. These subnets should have NAT gateway
+  access for outbound connectivity.
+
+**Private networking options** (set via `parameters.Private`):
+
+| Value | Behavior |
+|-------|----------|
+| `"false"` (default) | All runners use public subnets |
+| `"true"` | Runners with `private=true` workflow label use private subnets; others use public |
+| `"always"` | All runners use private subnets unless `private=false` label is specified |
+| `"only"` | All runners must use private subnets; public subnet execution is unavailable |
 
 (`_defaults.yaml`)
 
@@ -118,8 +153,12 @@ components:
         # Use Atmos KV Store
         # Use atmos !terraform.output yaml function
         vpc_id: !store auto/ssm vpc vpc_id
-        subnet_ids: !store auto/ssm vpc private_subnet_ids
+        subnet_ids: !store auto/ssm vpc public_subnet_ids
+        private_subnet_ids: !store auto/ssm vpc private_subnet_ids
         security_group_id: !store auto/ssm vpc default_security_group_id
+        parameters:
+          # Enable per-workflow control: use private=true label to place runner in private subnet
+          Private: "true"
 ```
 
 <details>

--- a/src/main.tf
+++ b/src/main.tf
@@ -12,7 +12,7 @@ locals {
   external_vpc_id    = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
   networking_stack   = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
   subnet_ids         = var.subnet_ids != null ? { (local.subnet_ids_param_name) = join(",", var.subnet_ids) } : {}
-  private_subnet_ids = var.private_subnet_ids != null ? { "ExternalVpcPrivateSubnetIds" = join(",", var.private_subnet_ids) } : {}
+  external_private_subnet_ids = var.private_subnet_ids != null ? { "ExternalVpcPrivateSubnetIds" = join(",", var.private_subnet_ids) } : {}
   // If var.security_group_id is provided, we use it. Otherwise, if we are using the external networking stack, we create one.
   external_security_group_id = var.security_group_id != null ? { "ExternalVpcSecurityGroupId" = var.security_group_id } : {}
   // If var.security_group_id is not provided and we are using the external networking stack, we create one.
@@ -24,7 +24,7 @@ locals {
     , local.networking_stack
     , local.external_vpc_id
     , local.subnet_ids
-    , local.private_subnet_ids
+    , local.external_private_subnet_ids
     , local.external_security_group_id
     , local.created_security_group_id
   )

--- a/src/main.tf
+++ b/src/main.tf
@@ -175,3 +175,28 @@ data "aws_nat_gateways" "ngws" {
   count  = local.enabled ? 1 : 0
   vpc_id = local.vpc_id
 }
+
+# Validate that external networking variables are not set when using embedded networking.
+# When networking_stack is "embedded", RunsOn creates its own VPC with subnets via CloudFormation,
+# so providing external subnet IDs would be ignored and is likely a configuration error.
+
+check "embedded_networking_no_vpc_id" {
+  assert {
+    condition     = var.networking_stack != "embedded" || var.vpc_id == null
+    error_message = "vpc_id should not be set when networking_stack is 'embedded'. RunsOn creates its own VPC when using embedded networking."
+  }
+}
+
+check "embedded_networking_no_subnet_ids" {
+  assert {
+    condition     = var.networking_stack != "embedded" || var.subnet_ids == null
+    error_message = "subnet_ids should not be set when networking_stack is 'embedded'. RunsOn creates its own subnets when using embedded networking."
+  }
+}
+
+check "embedded_networking_no_private_subnet_ids" {
+  assert {
+    condition     = var.networking_stack != "embedded" || var.private_subnet_ids == null
+    error_message = "private_subnet_ids should not be set when networking_stack is 'embedded'. RunsOn creates its own subnets when using embedded networking."
+  }
+}

--- a/src/main.tf
+++ b/src/main.tf
@@ -9,9 +9,10 @@ locals {
   use_new_subnet_param   = local.template_version_major > 2 || (local.template_version_major == 2 && local.template_version_minor >= 8)
   subnet_ids_param_name  = local.use_new_subnet_param ? "ExternalVpcPublicSubnetIds" : "ExternalVpcSubnetIds"
 
-  external_vpc_id  = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
-  networking_stack = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
-  subnet_ids       = var.subnet_ids != null ? { (local.subnet_ids_param_name) = join(",", var.subnet_ids) } : {}
+  external_vpc_id    = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
+  networking_stack   = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
+  subnet_ids         = var.subnet_ids != null ? { (local.subnet_ids_param_name) = join(",", var.subnet_ids) } : {}
+  private_subnet_ids = var.private_subnet_ids != null ? { "ExternalVpcPrivateSubnetIds" = join(",", var.private_subnet_ids) } : {}
   // If var.security_group_id is provided, we use it. Otherwise, if we are using the external networking stack, we create one.
   external_security_group_id = var.security_group_id != null ? { "ExternalVpcSecurityGroupId" = var.security_group_id } : {}
   // If var.security_group_id is not provided and we are using the external networking stack, we create one.
@@ -23,6 +24,7 @@ locals {
     , local.networking_stack
     , local.external_vpc_id
     , local.subnet_ids
+    , local.private_subnet_ids
     , local.external_security_group_id
     , local.created_security_group_id
   )

--- a/src/main.tf
+++ b/src/main.tf
@@ -9,9 +9,9 @@ locals {
   use_new_subnet_param   = local.template_version_major > 2 || (local.template_version_major == 2 && local.template_version_minor >= 8)
   subnet_ids_param_name  = local.use_new_subnet_param ? "ExternalVpcPublicSubnetIds" : "ExternalVpcSubnetIds"
 
-  external_vpc_id    = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
-  networking_stack   = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
-  subnet_ids         = var.subnet_ids != null ? { (local.subnet_ids_param_name) = join(",", var.subnet_ids) } : {}
+  external_vpc_id             = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
+  networking_stack            = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
+  subnet_ids                  = var.subnet_ids != null ? { (local.subnet_ids_param_name) = join(",", var.subnet_ids) } : {}
   external_private_subnet_ids = var.private_subnet_ids != null ? { "ExternalVpcPrivateSubnetIds" = join(",", var.private_subnet_ids) } : {}
   // If var.security_group_id is provided, we use it. Otherwise, if we are using the external networking stack, we create one.
   external_security_group_id = var.security_group_id != null ? { "ExternalVpcSecurityGroupId" = var.security_group_id } : {}

--- a/src/main.tf
+++ b/src/main.tf
@@ -3,16 +3,20 @@ locals {
 
   # Extract version from template URL (e.g., "template-v2.11.0.yaml" -> "2.11.0")
   # The parameter name changed from ExternalVpcSubnetIds to ExternalVpcPublicSubnetIds in v2.8.0
+  # The ExternalVpcPrivateSubnetIds parameter was added in v2.8.0
   version_match          = regex("template-v([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.yaml", var.template_url)
   template_version_major = tonumber(local.version_match[0])
   template_version_minor = tonumber(local.version_match[1])
   use_new_subnet_param   = local.template_version_major > 2 || (local.template_version_major == 2 && local.template_version_minor >= 8)
   subnet_ids_param_name  = local.use_new_subnet_param ? "ExternalVpcPublicSubnetIds" : "ExternalVpcSubnetIds"
 
+  # ExternalVpcPrivateSubnetIds is only supported in v2.8.0+
+  private_subnet_ids_supported = local.use_new_subnet_param
+
   external_vpc_id             = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
   networking_stack            = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
   subnet_ids                  = var.subnet_ids != null ? { (local.subnet_ids_param_name) = join(",", var.subnet_ids) } : {}
-  external_private_subnet_ids = var.private_subnet_ids != null ? { "ExternalVpcPrivateSubnetIds" = join(",", var.private_subnet_ids) } : {}
+  external_private_subnet_ids = var.private_subnet_ids != null && local.private_subnet_ids_supported ? { "ExternalVpcPrivateSubnetIds" = join(",", var.private_subnet_ids) } : {}
   // If var.security_group_id is provided, we use it. Otherwise, if we are using the external networking stack, we create one.
   external_security_group_id = var.security_group_id != null ? { "ExternalVpcSecurityGroupId" = var.security_group_id } : {}
   // If var.security_group_id is not provided and we are using the external networking stack, we create one.
@@ -198,5 +202,12 @@ check "embedded_networking_no_private_subnet_ids" {
   assert {
     condition     = var.networking_stack != "embedded" || var.private_subnet_ids == null
     error_message = "private_subnet_ids should not be set when networking_stack is 'embedded'. RunsOn creates its own subnets when using embedded networking."
+  }
+}
+
+check "private_subnet_ids_template_version" {
+  assert {
+    condition     = var.private_subnet_ids == null || local.private_subnet_ids_supported
+    error_message = "private_subnet_ids requires RunsOn CloudFormation template version 2.8.0 or newer. Please upgrade your template_url to a supported version."
   }
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -51,21 +51,44 @@ variable "networking_stack" {
 
 variable "vpc_id" {
   type        = string
-  description = "VPC ID"
+  description = <<-EOT
+    VPC ID for external networking (maps to ExternalVpcId).
+
+    This variable only applies when using `networking_stack = "external"` (bring your own VPC).
+    When using `networking_stack = "embedded"`, RunsOn creates its own VPC via CloudFormation,
+    so this variable should not be set.
+  EOT
   nullable    = true
   default     = null
 }
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "Public subnet IDs for runners (maps to ExternalVpcPublicSubnetIds). Used for runners without private=true label."
+  description = <<-EOT
+    Public subnet IDs for runners (maps to ExternalVpcPublicSubnetIds).
+
+    This variable only applies when using `networking_stack = "external"` (bring your own VPC).
+    When using `networking_stack = "embedded"`, RunsOn creates its own VPC with public and private
+    subnets via CloudFormation, so this variable should not be set.
+
+    Used for runners without the `private=true` label, or when `Private` parameter is set to `"false"`.
+  EOT
   nullable    = true
   default     = null
 }
 
 variable "private_subnet_ids" {
   type        = list(string)
-  description = "Private subnet IDs for runners (maps to ExternalVpcPrivateSubnetIds). Required when using Private: true or Private: always to place runners in private subnets."
+  description = <<-EOT
+    Private subnet IDs for runners (maps to ExternalVpcPrivateSubnetIds).
+
+    This variable only applies when using `networking_stack = "external"` (bring your own VPC).
+    When using `networking_stack = "embedded"`, RunsOn creates its own VPC with public and private
+    subnets via CloudFormation, so this variable should not be set.
+
+    Required when using external networking with `Private: "true"` or `Private: "always"` to place
+    runners in private subnets. These subnets should have NAT gateway access for outbound connectivity.
+  EOT
   nullable    = true
   default     = null
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -58,7 +58,14 @@ variable "vpc_id" {
 
 variable "subnet_ids" {
   type        = list(string)
-  description = "Subnet IDs"
+  description = "Public subnet IDs for runners (maps to ExternalVpcPublicSubnetIds). Used for runners without private=true label."
+  nullable    = true
+  default     = null
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for runners (maps to ExternalVpcPrivateSubnetIds). Required when using Private: true or Private: always to place runners in private subnets."
   nullable    = true
   default     = null
 }


### PR DESCRIPTION
## What
- Add `private_subnet_ids` variable that maps to CloudFormation `ExternalVpcPrivateSubnetIds` parameter
- Add validation using Terraform `check` blocks for networking configuration
- Add version guard requiring template v2.8.0+ for `private_subnet_ids`
- Update README with comprehensive networking documentation

## Why
When using RunsOn with external networking (`networking_stack: external`) and the `Private` CloudFormation parameter set to `"true"` or `"always"`, runners can be placed in private subnets. This requires configuring `ExternalVpcPrivateSubnetIds` in addition to `ExternalVpcPublicSubnetIds`.

Previously, users had to pass `ExternalVpcPrivateSubnetIds` through the generic `parameters` map. This change adds a dedicated variable for better discoverability and consistency with the existing `subnet_ids` variable.

## Changes

### New Variable
- `private_subnet_ids` - List of private subnet IDs for runners (maps to `ExternalVpcPrivateSubnetIds`)

### Validation (using `check` blocks)
- Error if `vpc_id`, `subnet_ids`, or `private_subnet_ids` are set with `networking_stack: embedded`
- Error if `private_subnet_ids` is used with template version < 2.8.0

### Documentation
- New "Networking Options" section explaining embedded vs external networking
- Table documenting `Private` parameter values (`"false"`, `"true"`, `"always"`, `"only"`)
- Updated examples showing `private_subnet_ids` usage

## Usage
```yaml
components:
  terraform:
    runs-on:
      vars:
        networking_stack: external
        vpc_id: vpc-xxx
        subnet_ids: ["subnet-public-1", "subnet-public-2"]
        private_subnet_ids: ["subnet-private-1", "subnet-private-2"]
        parameters:
          Private: "true"  # or "always"
```

## References
- RunsOn private networking: https://runs-on.com/networking/static-ips/
- RunsOn stack configuration: https://runs-on.com/configuration/stack-config/