### PR TITLE
feat!: Migrate RunsOn from CloudFormation to official Terraform module

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -32,16 +32,21 @@ contributors: [] # If included generates contribs
 description: |
   Component: `runs-on`
 
-  This component provisions RunsOn for GitHub Actions self-hosted runners. After deploying this
-  component, install the RunsOn GitHub App in your organization to enable runner registration.
-  See the RunsOn documentation for GitHub App installation and configuration details.
+  This component provisions RunsOn for GitHub Actions self-hosted runners using the official
+  [runs-on/terraform-aws-runs-on](https://github.com/runs-on/terraform-aws-runs-on) Terraform module.
 
-  Compatibility: Requires RunsOn CloudFormation template version 2.8.2 or newer due to output changes.
+  After deploying this component, install the RunsOn GitHub App in your organization to enable
+  runner registration. See the RunsOn documentation for GitHub App installation and configuration details.
+
+  **Requirements:**
+  - Terraform >= 1.5.7
+  - AWS Provider >= 6.0
+  - An existing VPC with public subnets (and private subnets if using private mode)
 # How to use this project
 usage: |
   Stack Level: Regional
 
-  (`runs-on/defaults.yaml`)
+  ### Stack Catalog (`runs-on/defaults.yaml`)
 
   ```yaml
   components:
@@ -53,37 +58,30 @@ usage: |
         vars:
           name: runs-on
           enabled: true
-          capabilities: ["CAPABILITY_IAM"]
-          on_failure: "ROLLBACK"
-          timeout_in_minutes: 30
-          # template_url: https://runs-on.s3.eu-west-1.amazonaws.com/cloudformation/template.yaml
-          # See latest version and changelog at https://runs-on.com/changelog/
-          template_url: https://runs-on.s3.eu-west-1.amazonaws.com/cloudformation/template-v2.8.3.yaml
-          parameters:
-            AppCPU: 256
-            AppMemory: 512
-            EmailAddress: developer@cloudposse.com
-            # Environments let you run multiple Stacks in one organization and segregate resources.
-            # If you specify an environment, then all the jobs must also specify which environment they are running in.
-            # To keep things simple, we use the default environment ("production") and leave the `env` label unset in the workflow.
-            EncryptEbs: true
-            # With the default value of SSHAllowed: true, the runners that are placed in a public subnet
-            # will allow ingress on port 22. This is highly abused (scanners running constantly looking for vulnerable SSH servers)
-            # and should not be allowed. If you need access to the runners, use Session Manager (SSM).
-            SSHAllowed: false
-            LicenseKey: <LICENSE_KEY>
-            Private: false # always | true | false - Always will default place in private subnet, true will place in private subnet if tag `private=true` present on workflow, false will place in public subnet
-            RunnerLargeDiskSize: 120 # Disk size in GB for disk=large runners
-            Ec2LogRetentionInDays: 30
-            VpcFlowLogRetentionInDays: 14
+
+          # Required inputs
+          github_organization: myorg
+          license_key: <RUNS_ON_LICENSE_KEY>
+          email: ops@example.com
+
+          # Networking
+          private_mode: "true"  # "false" | "true" | "always" | "only"
+          ssh_allowed: false
+
+          # Compute
+          app_cpu: 256
+          app_memory: 512
+          ebs_encryption_enabled: true
+          runner_large_disk_size: 120
+          log_retention_days: 30
+          app_alarm_daily_minutes: 4000
+
+          # Runner
+          runner_custom_tags:
+            - "org=myorg"
   ```
 
-  ### Embedded networking (Runs On managed VPC)
-
-  When no VPC details are set, the component will create a new VPC and subnets via the CloudFormation template.
-  Set the `VpcCidrBlock` parameter to the CIDR block of the VPC that will be created.
-
-  (`runs-on.yaml`)
+  ### Deploy with existing VPC (`runs-on.yaml`)
 
   ```yaml
   import:
@@ -99,63 +97,18 @@ usage: |
             - runs-on/defaults
           component: runs-on
         vars:
-          networking_stack: embedded
-          parameters:
-            VpcCidrBlock: 10.100.0.0/16
+          vpc_id: !terraform.state vpc vpc_id
+          public_subnet_ids: !terraform.state vpc public_subnet_ids
+          private_subnet_ids: !terraform.state vpc private_subnet_ids
   ```
 
-  ### External networking (Use existing VPC)
+  ### Transit Gateway integration
 
-  Use an existing VPC by setting `vpc_id`, `subnet_ids`, and `security_group_id`.
-
-  (`_defaults.yaml`)
-
-  ```yaml
-  terraform:
-    hooks:
-      store-outputs:
-        name: auto/ssm
-  ```
-
-  (`runs-on.yaml`)
+  The outputs of this component match the `vpc` component interface. This means you can
+  reference `runs-on` as a `vpc_component_name` in the `tgw/hub` and `tgw/spoke` components.
 
   ```yaml
-  import:
-    - orgs/acme/core/auto/_defaults
-    - mixins/region/us-east-1
-    - catalog/vpc/defaults
-    - catalog/runs-on/defaults
-
-  components:
-    terraform:
-      runs-on:
-        metadata:
-          inherits:
-            - runs-on/defaults
-          component: runs-on
-        vars:
-          networking_stack: external
-          # There are other ways to get the vpc_id, subnet_ids, and security_group_id.
-          # Hardcode
-          # Use Atmos KV Store
-          # Use atmos !terraform.output yaml function
-          vpc_id: !store auto/ssm vpc vpc_id
-          subnet_ids: !store auto/ssm vpc private_subnet_ids
-          security_group_id: !store auto/ssm vpc default_security_group_id
-  ```
-
-  <details>
-  <summary>(DEPRECATED) Configuring with Transit Gateway</summary>
-  It's important to note that the embedded networking will require some customization to work with Transit Gateway.
-  The following configuration assumes you are using the Cloud Posse Components for Transit Gateway
-  ([tgw/hub](https://docs.cloudposse.com/components/library/aws/tgw/hub/) &
-  [tgw/spoke](https://docs.cloudposse.com/components/library/aws/tgw/spoke/)).
-  The outputs of this component contain the same outputs as the `vpc` component. This is because the runs-on
-  cloudformation stack creates a VPC and subnets.
-  First we need to update the TGW/Hub - this stores information about the VPCs that are allowed to be used by TGW Spokes.
-  Assuming your TGW/Hub lives in the `core-network` account and your Runs-On is deployed to `core-auto` (`tgw-hub.yaml`)
-
-  ```yaml
+  # tgw-hub.yaml
   vars:
     connections:
       - account:
@@ -167,53 +120,7 @@ usage: |
   ```
 
   ```yaml
-  components:
-    terraform:
-      tgw/hub/defaults:
-        metadata:
-          type: abstract
-          component: tgw/hub
-        vars:
-          enabled: true
-          name: tgw-hub
-          tags:
-            Team: sre
-            Service: tgw-hub
-
-      tgw/hub:
-        metadata:
-          inherits:
-            - tgw/hub/defaults
-          component: tgw/hub
-        vars:
-          connections:
-            - account:
-                tenant: core
-                stage: network
-            - account:
-                tenant: core
-                stage: auto
-              vpc_component_names:
-                - vpc
-                - runs-on
-            - account:
-                tenant: plat
-                stage: sandbox
-            - account:
-                tenant: plat
-                stage: dev
-            - account:
-                tenant: plat
-                stage: staging
-            - account:
-                tenant: plat
-                stage: prod
-  ```
-
-  We then need to create a spoke that refers to the VPC created by Runs-On.
-  (`tgw-spoke.yaml`)
-
-  ```yaml
+  # tgw-spoke.yaml
   tgw/spoke/runs-on:
     metadata:
       component: tgw/spoke
@@ -233,52 +140,68 @@ usage: |
           vpc_component_names:
             - vpc
             - runs-on
-        - account:
-            tenant: plat
-            stage: sandbox
-        - account:
-            tenant: plat
-            stage: dev
-        - account:
-            tenant: plat
-            stage: staging
-        - account:
-            tenant: plat
-            stage: prod
   ```
 
-  Finally we need to update the spokes of the TGW/Spokes to allow Runs-On traffic to the other accounts.
-  Typically this includes `core-auto`, `core-network`, and your platform accounts.
-  (`tgw-spoke.yaml`)
+  ## Migration from v2.x (CloudFormation-based)
 
-  ```yaml
-    tgw/spoke:
-      metadata:
-        inherits:
-          - tgw/spoke-defaults
-      vars:
-        connections:
-          # ...
-              vpc_component_names:
-                - vpc
-                - runs-on
-          # ...
-  ```
-  </details>
+  Version 3.0 replaces the CloudFormation template wrapper with the official
+  [runs-on/terraform-aws-runs-on](https://github.com/runs-on/terraform-aws-runs-on) Terraform module.
+
+  ### Breaking Changes
+
+  1. **AWS provider >= 6.0 required**
+  2. **Embedded networking removed** — only external/BYOV mode is supported
+  3. **`parameters` map replaced with flat variables** — see mapping table below
+  4. **Destructive migration** — CloudFormation stack will be destroyed and resources recreated
+  5. **GitHub App reinstallation required** — App Runner URL changes after migration
+  6. **`subnet_ids` renamed to `public_subnet_ids`**
+
+  ### Variable Mapping
+
+  | Old (v2.x) | New (v3.0) |
+  |------------|-----------|
+  | `template_url` | removed |
+  | `capabilities` | removed |
+  | `on_failure` | removed |
+  | `timeout_in_minutes` | removed |
+  | `networking_stack` | removed (external-only) |
+  | `subnet_ids` | `public_subnet_ids` |
+  | `parameters.LicenseKey` | `license_key` |
+  | `parameters.GithubOrganization` | `github_organization` |
+  | `parameters.EmailAddress` | `email` |
+  | `parameters.Private` | `private_mode` |
+  | `parameters.SSHAllowed` | `ssh_allowed` (bool) |
+  | `parameters.EncryptEbs` | `ebs_encryption_enabled` (bool) |
+  | `parameters.AppCPU` | `app_cpu` |
+  | `parameters.AppMemory` | `app_memory` |
+  | `parameters.RunnerLargeDiskSize` | `runner_large_disk_size` |
+  | `parameters.Ec2LogRetentionInDays` | `log_retention_days` |
+  | `parameters.RunnerCustomTags` | `runner_custom_tags` (list) |
+  | `parameters.AppAlarmDailyMinutes` | `app_alarm_daily_minutes` |
+  | `parameters.VpcFlowLogRetentionInDays` | removed |
+
+  ### Migration Steps
+
+  1. Update the component source (vendor pull)
+  2. Update your stack catalog YAML — flatten `parameters` into individual variables
+  3. Run `atmos terraform plan runs-on -s core-<region>-auto` to review the plan
+  4. Apply — this will destroy the CloudFormation stack and create resources natively via Terraform
+  5. Re-install the RunsOn GitHub App using the new `apprunner_service_url` output
+
 # Helpful links
 references:
   - name: RunsOn
     description: ""
     url: https://runs-on.com/
+  - name: RunsOn Terraform Module
+    description: "Official Terraform module for provisioning RunsOn"
+    url: https://github.com/runs-on/terraform-aws-runs-on
   - name: Install RunsOn GitHub App
     description: ""
     url: https://runs-on.com/guides/install/#3-github-app-registration
   - name: RunsOn Changelog
     description: ""
     url: https://runs-on.com/changelog/
-  - name: Embedded vs External Networking
-    description: ""
-    url: https://runs-on.com/networking/embedded-vs-external/
   - name: Cloud Posse TGW Hub component
     description: ""
     url: https://docs.cloudposse.com/components/library/aws/tgw/hub/

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,52 +1,87 @@
 locals {
   enabled = module.this.enabled
 
-  # Extract version from template URL (e.g., "template-v2.11.0.yaml" -> "2.11.0")
-  # The parameter name changed from ExternalVpcSubnetIds to ExternalVpcPublicSubnetIds in v2.8.0
-  # The ExternalVpcPrivateSubnetIds parameter was added in v2.8.0
-  version_match          = regex("template-v([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.yaml", var.template_url)
-  template_version_major = tonumber(local.version_match[0])
-  template_version_minor = tonumber(local.version_match[1])
-  use_new_subnet_param   = local.template_version_major > 2 || (local.template_version_major == 2 && local.template_version_minor >= 8)
-  subnet_ids_param_name  = local.use_new_subnet_param ? "ExternalVpcPublicSubnetIds" : "ExternalVpcSubnetIds"
+  # Merge singular security_group_id with security_group_ids list for backward compatibility
+  security_group_ids = compact(concat(
+    var.security_group_ids,
+    var.security_group_id != null ? [var.security_group_id] : []
+  ))
 
-  # ExternalVpcPrivateSubnetIds is only supported in v2.8.0+
-  private_subnet_ids_supported = local.use_new_subnet_param
-
-  external_vpc_id             = var.vpc_id != null ? { "ExternalVpcId" = var.vpc_id } : {}
-  networking_stack            = var.networking_stack != null ? { "NetworkingStack" = var.networking_stack } : {}
-  subnet_ids                  = var.subnet_ids != null ? { (local.subnet_ids_param_name) = join(",", var.subnet_ids) } : {}
-  external_private_subnet_ids = var.private_subnet_ids != null && local.private_subnet_ids_supported ? { "ExternalVpcPrivateSubnetIds" = join(",", var.private_subnet_ids) } : {}
-  // If var.security_group_id is provided, we use it. Otherwise, if we are using the external networking stack, we create one.
-  external_security_group_id = var.security_group_id != null ? { "ExternalVpcSecurityGroupId" = var.security_group_id } : {}
-  // If var.security_group_id is not provided and we are using the external networking stack, we create one.
-  created_security_group_id = var.security_group_id == null && var.networking_stack == "external" ? { "ExternalVpcSecurityGroupId" = module.security_group.id } : {}
-
-  parameters = merge({
-    "EC2InstanceCustomPolicy" = module.iam_policy.policy_arn
-    }, var.parameters
-    , local.networking_stack
-    , local.external_vpc_id
-    , local.subnet_ids
-    , local.external_private_subnet_ids
-    , local.external_security_group_id
-    , local.created_security_group_id
-  )
-
+  # Use module.this.id as stack_name if not explicitly set
+  stack_name = var.stack_name != null ? var.stack_name : module.this.id
 }
+
+module "runs_on" {
+  count = local.enabled ? 1 : 0
+
+  source  = "runs-on/runs-on/aws"
+  version = "2.11.0-r1"
+
+  # Required inputs
+  github_organization = var.github_organization
+  license_key         = var.license_key
+  vpc_id              = var.vpc_id
+  public_subnet_ids   = var.public_subnet_ids
+  email               = var.email
+
+  # Networking
+  private_subnet_ids = var.private_subnet_ids
+  private_mode       = var.private_mode
+  security_group_ids = local.security_group_ids
+  ssh_allowed        = var.ssh_allowed
+  ssh_cidr_range     = var.ssh_cidr_range
+  ipv6_enabled       = var.ipv6_enabled
+
+  # Compute / App Runner
+  app_cpu                  = var.app_cpu
+  app_memory               = var.app_memory
+  ebs_encryption_enabled   = var.ebs_encryption_enabled
+  runner_large_disk_size   = var.runner_large_disk_size
+  runner_default_disk_size = var.runner_default_disk_size
+  log_retention_days       = var.log_retention_days
+  permission_boundary_arn  = var.permission_boundary_arn
+
+  # Runner configuration
+  runner_custom_tags = var.runner_custom_tags
+
+  # Naming / environment
+  stack_name  = local.stack_name
+  environment = var.runs_on_environment
+
+  # Monitoring
+  app_alarm_daily_minutes = var.app_alarm_daily_minutes
+
+  # Optional features
+  enable_efs = var.enable_efs
+  enable_ecr = var.enable_ecr
+  enable_waf = var.enable_waf
+
+  # Storage
+  cache_expiration_days = var.cache_expiration_days
+  force_destroy_buckets = var.force_destroy_buckets
+
+  # Tags - pass Cloud Posse context tags
+  tags = module.this.tags
+}
+
+# -----------------------------------------------------------------------------
+# Custom ECR IAM policy for runner instances
+# This grants runners access to existing ECR repositories in the account,
+# independent of the module's enable_ecr feature (which creates a new repo).
+# -----------------------------------------------------------------------------
 
 module "iam_policy" {
   source  = "cloudposse/iam-policy/aws"
   version = "2.0.2"
 
   context = module.this.context
-  enabled = module.this.enabled
+  enabled = local.enabled
 
   iam_policy_enabled = true
   iam_policy = [
     {
       version   = "2012-10-17"
-      policy_id = "example"
+      policy_id = "RunsOnECRAccess"
       statements = [
         {
           sid    = "AllowECRActions"
@@ -84,28 +119,27 @@ module "iam_policy" {
   ]
 }
 
-// Typically when runs-on is installed, and we're using the embedded networking stack, we need a security group.
-// This is a batties included optional feature.
-module "security_group" {
-  source  = "cloudposse/security-group/aws"
-  version = "2.2.0"
+# Attach the custom ECR policy to the module's EC2 instance role
+resource "aws_iam_role_policy_attachment" "ecr_custom" {
+  count = local.enabled ? 1 : 0
 
-  // Enabled if we are using the external networking stack and no security group ID is provided
-  enabled = local.enabled && var.networking_stack == "external" && var.security_group_id == null
-
-  // This cannot be local.vpc_id because that would create a dependency cycle - as the local.vpc_id is determined as the resulting VPC id.
-  // The vpc_id is the created vpc by runs-on, or the one provided by the user if using the external networking stack.
-  // Thus the security group ID (which is passed in as `ExternalVpcSecurityGroupId` as a parameter to the stack) cannot depend on the stacks' vpc_id.
-  // `var.vpc_id` is safe to use here, because the networking_stack is required to be external for this.
-  vpc_id = var.vpc_id
-
-  context = module.this.context
+  role       = one(module.runs_on[*].ec2_instance_role_name)
+  policy_arn = module.iam_policy.policy_arn
 }
 
-resource "aws_security_group_rule" "this" {
-  for_each = var.security_group_rules != null && local.enabled ? { for rule in var.security_group_rules : md5(jsonencode(rule)) => rule } : {}
+# -----------------------------------------------------------------------------
+# Additional security group rules
+# Applied to the first security group from the module's output.
+# The module auto-creates a SG (with all outbound + optional SSH) when
+# security_group_ids is empty; these rules add to that SG.
+# -----------------------------------------------------------------------------
 
-  security_group_id = local.security_group_id
+resource "aws_security_group_rule" "this" {
+  for_each = var.security_group_rules != null && local.enabled ? {
+    for rule in var.security_group_rules : md5(jsonencode(rule)) => rule
+  } : {}
+
+  security_group_id = one(module.runs_on[*].security_group_ids[0])
 
   type        = each.value.type
   from_port   = each.value.from_port
@@ -114,100 +148,16 @@ resource "aws_security_group_rule" "this" {
   cidr_blocks = each.value.cidr_blocks
 }
 
-module "cloudformation_stack" {
-  count = local.enabled ? 1 : 0
-
-  source  = "cloudposse/cloudformation-stack/aws"
-  version = "0.7.1"
-
-  enabled = var.enabled
-  context = module.this.context
-
-  template_url       = var.template_url
-  parameters         = local.parameters
-  capabilities       = var.capabilities
-  on_failure         = var.on_failure
-  timeout_in_minutes = var.timeout_in_minutes
-  policy_body        = var.policy_body
-
-  depends_on = [module.iam_policy]
-}
+# -----------------------------------------------------------------------------
+# Data sources for TGW-compatible outputs
+# -----------------------------------------------------------------------------
 
 data "aws_vpc" "this" {
   count = local.enabled ? 1 : 0
-  id    = local.vpc_id
-}
-
-data "aws_subnets" "private" {
-  count = local.enabled ? 1 : 0
-  filter {
-    name   = "vpc-id"
-    values = [local.vpc_id]
-  }
-  filter {
-    name   = "map-public-ip-on-launch"
-    values = ["false"]
-  }
-}
-
-data "aws_subnets" "public" {
-  count = local.enabled ? 1 : 0
-  filter {
-    name   = "vpc-id"
-    values = [local.vpc_id]
-  }
-  filter {
-    name   = "map-public-ip-on-launch"
-    values = ["true"]
-  }
-}
-
-locals {
-  vpc_id             = var.networking_stack == "embedded" ? one(module.cloudformation_stack[*].outputs["RunsOnVPCId"]) : var.vpc_id
-  vpc_cidr_block     = var.networking_stack == "embedded" ? one(module.cloudformation_stack[*].outputs["RunsOnVpcCidrBlock"]) : one(data.aws_vpc.this[*].cidr_block)
-  public_subnet_ids  = one(data.aws_subnets.public[*].ids)
-  private_subnet_ids = one(data.aws_subnets.private[*].ids)
-  private_route_table_ids = var.networking_stack == "embedded" ? compact([
-    one(module.cloudformation_stack[*].outputs["RunsOnPrivateRouteTable1Id"]),
-    one(module.cloudformation_stack[*].outputs["RunsOnPrivateRouteTable2Id"]),
-    one(module.cloudformation_stack[*].outputs["RunsOnPrivateRouteTable3Id"]),
-  ]) : []
-  security_group_id = one(module.cloudformation_stack[*].outputs["RunsOnSecurityGroupId"])
+  id    = var.vpc_id
 }
 
 data "aws_nat_gateways" "ngws" {
   count  = local.enabled ? 1 : 0
-  vpc_id = local.vpc_id
-}
-
-# Validate that external networking variables are not set when using embedded networking.
-# When networking_stack is "embedded", RunsOn creates its own VPC with subnets via CloudFormation,
-# so providing external subnet IDs would be ignored and is likely a configuration error.
-
-check "embedded_networking_no_vpc_id" {
-  assert {
-    condition     = var.networking_stack != "embedded" || var.vpc_id == null
-    error_message = "vpc_id should not be set when networking_stack is 'embedded'. RunsOn creates its own VPC when using embedded networking."
-  }
-}
-
-check "embedded_networking_no_subnet_ids" {
-  assert {
-    condition     = var.networking_stack != "embedded" || var.subnet_ids == null
-    error_message = "subnet_ids should not be set when networking_stack is 'embedded'. RunsOn creates its own subnets when using embedded networking."
-  }
-}
-
-check "embedded_networking_no_private_subnet_ids" {
-  assert {
-    condition     = var.networking_stack != "embedded" || var.private_subnet_ids == null
-    error_message = "private_subnet_ids should not be set when networking_stack is 'embedded'. RunsOn creates its own subnets when using embedded networking."
-  }
-}
-
-check "private_subnet_ids_template_version" {
-  assert {
-    condition     = var.private_subnet_ids == null || local.private_subnet_ids_supported
-    error_message = "private_subnet_ids requires RunsOn CloudFormation template version 2.8.0 or newer. Please upgrade your template_url to a supported version."
-  }
+  vpc_id = var.vpc_id
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,55 +1,110 @@
-output "name" {
-  value       = one(module.cloudformation_stack[*].name)
-  description = "Name of the CloudFormation Stack"
-}
-
-output "id" {
-  value       = one(module.cloudformation_stack[*].id)
-  description = "ID of the CloudFormation Stack"
-}
-
-output "outputs" {
-  value       = one(module.cloudformation_stack[*].outputs)
-  description = "Outputs of the CloudFormation Stack"
-}
+# -----------------------------------------------------------------------------
+# TGW-compatible outputs
+# These outputs match the vpc component interface so the tgw/spoke component
+# can reference runs-on as a vpc_component_name.
+# -----------------------------------------------------------------------------
 
 output "vpc_id" {
-  value       = local.vpc_id
-  description = "ID of the VPC created by RunsOn CloudFormation Stack"
+  value       = local.enabled ? var.vpc_id : null
+  description = "VPC ID used by RunsOn"
 }
 
 output "vpc_cidr" {
-  value       = local.vpc_cidr_block
-  description = "CIDR of the VPC created by RunsOn CloudFormation Stack"
+  value       = one(data.aws_vpc.this[*].cidr_block)
+  description = "CIDR block of the VPC used by RunsOn"
 }
 
 output "nat_gateway_ids" {
   value       = one(data.aws_nat_gateways.ngws[*].ids)
-  description = "NAT Gateway IDs"
+  description = "NAT Gateway IDs in the VPC"
 }
 
-# Required by TGW Component but not created by RunsOn CloudFormation Stack
+# Required by TGW component but not directly managed by RunsOn
 output "nat_instance_ids" {
   value       = []
-  description = "NAT Instance IDs"
+  description = "NAT Instance IDs (always empty, kept for TGW compatibility)"
 }
 
 output "private_subnet_ids" {
-  value       = local.private_subnet_ids
-  description = "Private subnet IDs"
+  value       = local.enabled ? var.private_subnet_ids : []
+  description = "Private subnet IDs used by RunsOn"
 }
 
 output "public_subnet_ids" {
-  value       = local.public_subnet_ids
-  description = "Public subnet IDs"
+  value       = local.enabled ? var.public_subnet_ids : []
+  description = "Public subnet IDs used by RunsOn"
 }
 
 output "security_group_id" {
-  value       = local.security_group_id
-  description = "Security group ID"
+  value       = local.enabled ? one(module.runs_on[*].security_group_ids[0]) : null
+  description = "Primary security group ID used by RunsOn runners"
 }
 
 output "private_route_table_ids" {
-  value       = local.private_route_table_ids
-  description = "Private subnet route table IDs"
+  value       = []
+  description = "Private route table IDs (always empty in external/BYOV mode)"
+}
+
+# -----------------------------------------------------------------------------
+# RunsOn-specific outputs
+# -----------------------------------------------------------------------------
+
+output "name" {
+  value       = local.enabled ? local.stack_name : null
+  description = "RunsOn stack name"
+}
+
+output "id" {
+  value       = module.this.id
+  description = "Component ID"
+}
+
+output "outputs" {
+  value = local.enabled ? {
+    apprunner_service_url  = one(module.runs_on[*].apprunner_service_url)
+    apprunner_service_arn  = one(module.runs_on[*].apprunner_service_arn)
+    ec2_instance_role_name = one(module.runs_on[*].ec2_instance_role_name)
+    ec2_instance_role_arn  = one(module.runs_on[*].ec2_instance_role_arn)
+    security_group_ids     = one(module.runs_on[*].security_group_ids)
+    config_bucket_name     = one(module.runs_on[*].config_bucket_name)
+    cache_bucket_name      = one(module.runs_on[*].cache_bucket_name)
+    dashboard_url          = one(module.runs_on[*].dashboard_url)
+    sns_topic_arn          = one(module.runs_on[*].sns_topic_arn)
+  } : {}
+  description = "Selected outputs from the RunsOn Terraform module"
+}
+
+output "apprunner_service_url" {
+  value       = one(module.runs_on[*].apprunner_service_url)
+  description = "App Runner service URL (use this for GitHub App installation)"
+}
+
+output "dashboard_url" {
+  value       = one(module.runs_on[*].dashboard_url)
+  description = "CloudWatch dashboard URL"
+}
+
+output "ec2_instance_role_name" {
+  value       = one(module.runs_on[*].ec2_instance_role_name)
+  description = "EC2 instance IAM role name for runners"
+}
+
+output "ec2_instance_role_arn" {
+  value       = one(module.runs_on[*].ec2_instance_role_arn)
+  description = "EC2 instance IAM role ARN for runners"
+}
+
+output "security_group_ids" {
+  value       = one(module.runs_on[*].security_group_ids)
+  description = "Security group IDs used by RunsOn runners"
+}
+
+output "config_bucket_name" {
+  value       = one(module.runs_on[*].config_bucket_name)
+  description = "S3 bucket for RunsOn configuration"
+}
+
+output "cache_bucket_name" {
+  value       = one(module.runs_on[*].cache_bucket_name)
+  description = "S3 bucket for RunsOn cache"
 }

--- a/src/variables.tf
+++ b/src/variables.tf
@@ -3,101 +3,80 @@ variable "region" {
   description = "AWS Region"
 }
 
-variable "template_url" {
+# -----------------------------------------------------------------------------
+# Required inputs
+# -----------------------------------------------------------------------------
+
+variable "github_organization" {
   type        = string
-  description = "Amazon S3 bucket URL location of a file containing the CloudFormation template body. Maximum file size: 460,800 bytes"
+  description = "GitHub organization or username for RunsOn integration"
 }
 
-variable "parameters" {
-  type        = map(string)
-  description = "Key-value map of input parameters for the Stack Set template. (_e.g._ map(\"BusinessUnit\",\"ABC\")"
-  default     = {}
-}
-
-variable "capabilities" {
-  type        = list(string)
-  description = "A list of capabilities. Valid values: CAPABILITY_IAM, CAPABILITY_NAMED_IAM, CAPABILITY_AUTO_EXPAND"
-  default     = []
-}
-
-variable "on_failure" {
+variable "license_key" {
   type        = string
-  default     = "ROLLBACK"
-  description = "Action to be taken if stack creation fails. This must be one of: `DO_NOTHING`, `ROLLBACK`, or `DELETE`"
+  sensitive   = true
+  description = "RunsOn license key. See https://runs-on.com/pricing/"
 }
 
-variable "timeout_in_minutes" {
-  type        = number
-  default     = 30
-  description = "The amount of time that can pass before the stack status becomes `CREATE_FAILED`"
-}
-
-variable "policy_body" {
+variable "email" {
   type        = string
-  default     = ""
-  description = "Structure containing the stack policy body"
-}
-
-variable "networking_stack" {
-  type        = string
-  description = "Let RunsOn manage your networking stack (`embedded`), or use a vpc under your control (`external`). Null will default to whatever the template used as default. If you select `external`, you will need to provide the VPC ID, the subnet IDs, and optionally the security group ID, and make sure your whole networking setup is compatible with RunsOn (see https://runs-on.com/networking/embedded-vs-external/ for more details). To get started quickly, we recommend using the 'embedded' option."
-  nullable    = true
-  default     = "embedded"
-  validation {
-    condition     = contains(["embedded", "external"], var.networking_stack) || var.networking_stack == null
-    error_message = "Networking stack must be either `embedded` or `external`."
-  }
+  description = "Email address for RunsOn alert notifications"
 }
 
 variable "vpc_id" {
   type        = string
-  description = <<-EOT
-    VPC ID for external networking (maps to ExternalVpcId).
-
-    This variable only applies when using `networking_stack = "external"` (bring your own VPC).
-    When using `networking_stack = "embedded"`, RunsOn creates its own VPC via CloudFormation,
-    so this variable should not be set.
-  EOT
-  nullable    = true
-  default     = null
+  description = "VPC ID for RunsOn deployment. RunsOn resources will be created in this VPC."
 }
 
-variable "subnet_ids" {
+variable "public_subnet_ids" {
   type        = list(string)
   description = <<-EOT
-    Public subnet IDs for runners (maps to ExternalVpcPublicSubnetIds).
-
-    This variable only applies when using `networking_stack = "external"` (bring your own VPC).
-    When using `networking_stack = "embedded"`, RunsOn creates its own VPC with public and private
-    subnets via CloudFormation, so this variable should not be set.
-
-    Used for runners without the `private=true` label, or when `Private` parameter is set to `"false"`.
+    Public subnet IDs for runners. At least one is required.
+    Used for runners without the `private=true` label, or when `private_mode` is `"false"`.
   EOT
-  nullable    = true
-  default     = null
 }
+
+# -----------------------------------------------------------------------------
+# Networking
+# -----------------------------------------------------------------------------
 
 variable "private_subnet_ids" {
   type        = list(string)
   description = <<-EOT
-    Private subnet IDs for runners (maps to ExternalVpcPrivateSubnetIds).
-
-    This variable only applies when using `networking_stack = "external"` (bring your own VPC).
-    When using `networking_stack = "embedded"`, RunsOn creates its own VPC with public and private
-    subnets via CloudFormation, so this variable should not be set.
-
-    Required when using external networking with `Private: "true"` or `Private: "always"` to place
-    runners in private subnets. These subnets should have NAT gateway access for outbound connectivity.
+    Private subnet IDs for runners.
+    Required when `private_mode` is not `"false"`. These subnets should have NAT gateway
+    access for outbound connectivity.
   EOT
-  nullable    = true
-  default     = null
+  default     = []
+}
+
+variable "private_mode" {
+  type        = string
+  description = <<-EOT
+    Controls how runners are placed in subnets:
+    - `"false"`: All runners use public subnets (default)
+    - `"true"`: Private networking available; runners opt-in via `private=true` workflow label
+    - `"always"`: Private networking is default; runners can opt-out
+    - `"only"`: All runners MUST use private subnets
+  EOT
+  default     = "true"
+  validation {
+    condition     = contains(["false", "true", "always", "only"], var.private_mode)
+    error_message = "private_mode must be one of: \"false\", \"true\", \"always\", \"only\"."
+  }
 }
 
 variable "security_group_id" {
   type        = string
-  description = "Security group ID. If not set, a new security group will be created."
+  description = "Security group ID to use for runners. If not set and security_group_ids is empty, one will be created by the module."
   nullable    = true
   default     = null
+}
+
+variable "security_group_ids" {
+  type        = list(string)
+  description = "List of security group IDs to use for runners. If empty and security_group_id is not set, one will be created by the module."
+  default     = []
 }
 
 variable "security_group_rules" {
@@ -108,7 +87,146 @@ variable "security_group_rules" {
     protocol    = string
     cidr_blocks = list(string)
   }))
-  description = "Security group rules. These are either added to the security passed in, or added to the security group created when var.security_group_id is not set. Types include `ingress` and `egress`."
+  description = "Additional security group rules to apply to the runner security group."
   nullable    = true
   default     = null
+}
+
+variable "ssh_allowed" {
+  type        = bool
+  description = "Whether SSH access is allowed to runners. Recommend false; use SSM instead."
+  default     = false
+}
+
+variable "ssh_cidr_range" {
+  type        = string
+  description = "CIDR range for SSH access when ssh_allowed is true."
+  default     = "0.0.0.0/0"
+}
+
+variable "ipv6_enabled" {
+  type        = bool
+  description = "Enable IPv6 support."
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Compute / App Runner
+# -----------------------------------------------------------------------------
+
+variable "app_cpu" {
+  type        = number
+  description = "CPU units for the RunsOn App Runner service."
+  default     = 256
+}
+
+variable "app_memory" {
+  type        = number
+  description = "Memory in MB for the RunsOn App Runner service."
+  default     = 512
+}
+
+variable "ebs_encryption_enabled" {
+  type        = bool
+  description = "Enable EBS encryption for runner volumes."
+  default     = true
+}
+
+variable "runner_default_disk_size" {
+  type        = number
+  description = "Default EBS volume size in GB for runners."
+  default     = 40
+}
+
+variable "runner_large_disk_size" {
+  type        = number
+  description = "EBS volume size in GB for runners using disk=large label."
+  default     = 120
+}
+
+variable "log_retention_days" {
+  type        = number
+  description = "CloudWatch log retention in days for runner logs."
+  default     = 30
+}
+
+variable "permission_boundary_arn" {
+  type        = string
+  description = "IAM permissions boundary ARN for roles created by the module."
+  default     = ""
+}
+
+# -----------------------------------------------------------------------------
+# Runner configuration
+# -----------------------------------------------------------------------------
+
+variable "runner_custom_tags" {
+  type        = list(string)
+  description = "Custom tags for runner instances (e.g., [\"org=myorg\"])."
+  default     = []
+}
+
+variable "runs_on_environment" {
+  type        = string
+  description = <<-EOT
+    RunsOn environment identifier (e.g., "production").
+    Note: This is the RunsOn environment, not the Cloud Posse context environment.
+    If you run multiple RunsOn stacks in one organization, use different environments to segregate resources.
+  EOT
+  default     = "production"
+}
+
+variable "stack_name" {
+  type        = string
+  description = "Name for the RunsOn stack, used in resource naming. Defaults to the Cloud Posse module ID if not set."
+  nullable    = true
+  default     = null
+}
+
+# -----------------------------------------------------------------------------
+# Optional features
+# -----------------------------------------------------------------------------
+
+variable "enable_efs" {
+  type        = bool
+  description = "Enable EFS shared storage for runners."
+  default     = false
+}
+
+variable "enable_ecr" {
+  type        = bool
+  description = "Enable ECR image registry managed by RunsOn."
+  default     = false
+}
+
+variable "enable_waf" {
+  type        = bool
+  description = "Enable WAF on the App Runner service."
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Storage
+# -----------------------------------------------------------------------------
+
+variable "cache_expiration_days" {
+  type        = number
+  description = "Number of days before S3 cache objects expire."
+  default     = 10
+}
+
+variable "force_destroy_buckets" {
+  type        = bool
+  description = "Allow destruction of non-empty S3 buckets during teardown."
+  default     = false
+}
+
+# -----------------------------------------------------------------------------
+# Monitoring
+# -----------------------------------------------------------------------------
+
+variable "app_alarm_daily_minutes" {
+  type        = number
+  description = "Daily alarm threshold in minutes for App Runner usage."
+  default     = 4000
 }

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -1,10 +1,18 @@
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.5.7"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9.0, < 6.0.0"
+      version = ">= 6.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace CloudFormation template wrapper (`cloudposse/cloudformation-stack/aws`) with the official `runs-on/terraform-aws-runs-on` Terraform module (v2.11.0-r1)
- Flatten `parameters` map into first-class Terraform variables with proper types, defaults, and validation
- Preserve TGW-compatible outputs (`vpc_id`, `vpc_cidr`, `nat_gateway_ids`, `private_subnet_ids`, `public_subnet_ids`, `security_group_id`, `private_route_table_ids`)
- Keep custom ECR IAM policy, attach to module's EC2 instance role via `aws_iam_role_policy_attachment`

## Breaking Changes

| Change | Details |
|--------|---------|
| AWS provider >= 6.0 | Required by the official module |
| Embedded networking removed | External/BYOV only |
| `parameters` map removed | All config via flat variables |
| `subnet_ids` renamed | Now `public_subnet_ids` |
| Destructive migration | CF stack destroyed, resources recreated via Terraform |
| GitHub App reinstall | App Runner URL changes |

## Variable Mapping (old → new)

| Old (v2.x) | New (v3.0) |
|------------|-----------|
| `template_url` | removed |
| `parameters.LicenseKey` | `license_key` |
| `parameters.GithubOrganization` | `github_organization` |
| `parameters.EmailAddress` | `email` |
| `parameters.Private` | `private_mode` |
| `parameters.SSHAllowed` | `ssh_allowed` (bool) |
| `parameters.EncryptEbs` | `ebs_encryption_enabled` (bool) |
| `parameters.AppCPU` | `app_cpu` |
| `parameters.AppMemory` | `app_memory` |
| `parameters.RunnerLargeDiskSize` | `runner_large_disk_size` |
| `parameters.Ec2LogRetentionInDays` | `log_retention_days` |
| `parameters.RunnerCustomTags` | `runner_custom_tags` (list) |
| `networking_stack` | removed (external-only) |
| `subnet_ids` | `public_subnet_ids` |

## Test plan

- [x] `terraform fmt` passes
- [x] `terraform validate` passes
- [ ] Deploy to test environment and verify runners launch correctly
- [ ] Verify `private=true` workflow label places runners in private subnets
- [ ] Verify TGW spoke integration works with preserved outputs
- [ ] Verify GitHub App installation via `apprunner_service_url` output

Closes DEV-3968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Migrated to dedicated Terraform module for streamlined infrastructure provisioning
  * Added support for existing VPC deployments with enhanced networking flexibility
  * Introduced optional features: EFS, ECR, and WAF integration
  * Added new monitoring and security configuration options

* **Documentation**
  * Updated configuration guide to reflect Terraform module approach
  * Simplified deployment workflow and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->